### PR TITLE
fix: compare identifier name with either queryFn or mutationFn

### DIFF
--- a/packages/vite/src/babel.ts
+++ b/packages/vite/src/babel.ts
@@ -95,7 +95,7 @@ export function createTransformpRPC$(adapter: PRPCAdapter) {
               if (t.isObjectExpression(arg)) {
                 serverFunction = (
                   arg.properties.find((prop: any) =>
-                    prop.key.name === isQuery ? 'queryFn' : 'mutationFn'
+                    prop.key.name === (isQuery ? 'queryFn' : 'mutationFn')
                   ) as any
                 ).value
                 key = (


### PR DESCRIPTION
Fixes this [issue](https://github.com/OrJDev/prpc/issues/44#issuecomment-1499474861)